### PR TITLE
[기능] 가게 상세목록 조회

### DIFF
--- a/src/main/java/com/backmin/domains/common/aop/GlobalExceptionHandler.java
+++ b/src/main/java/com/backmin/domains/common/aop/GlobalExceptionHandler.java
@@ -2,6 +2,7 @@ package com.backmin.domains.common.aop;
 
 import com.backmin.domains.common.dto.ApiResult;
 import com.backmin.domains.common.enums.ErrorInfo;
+import com.backmin.domains.common.exception.BusinessException;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.validation.FieldError;
 import org.springframework.web.bind.MethodArgumentNotValidException;
@@ -24,6 +25,15 @@ public class GlobalExceptionHandler {
             .forEach(error -> errors.put(((FieldError) error).getField(), error.getDefaultMessage()));
 
         return ApiResult.error("METHOD_ARG_NOT_VALID", errors);
+    }
+
+    @ExceptionHandler(BusinessException.class)
+    public ApiResult<?> handleBusinessExceptionException(BusinessException ex) {
+        log.error("{}", ex);
+
+        ErrorInfo errorInfo = ex.getErrorInfo();
+
+        return ApiResult.error(errorInfo.getCode(), errorInfo.getMessage());
     }
 
     @ExceptionHandler(Exception.class)

--- a/src/main/java/com/backmin/domains/common/enums/ErrorInfo.java
+++ b/src/main/java/com/backmin/domains/common/enums/ErrorInfo.java
@@ -6,7 +6,8 @@ import lombok.Getter;
 public enum ErrorInfo {
 
     METHOD_ARG_NOT_VALID("METHOD_ARG_NOT_VALID", ""),
-    UNKNOWN("UNKNOWN", "서버 에러로 인해 데이터를 로드 할 수 없습니다.");
+    UNKNOWN("UNKNOWN", "서버 에러로 인해 데이터를 로드 할 수 없습니다."),
+    STORE_NOT_FOUND("STORE_NOT_FOUND", "해당 가게를 찾을 수 없습니다.");
 
     ErrorInfo(String code, String message) {
         this.code = code;

--- a/src/main/java/com/backmin/domains/common/exception/BusinessException.java
+++ b/src/main/java/com/backmin/domains/common/exception/BusinessException.java
@@ -1,0 +1,14 @@
+package com.backmin.domains.common.exception;
+
+import com.backmin.domains.common.enums.ErrorInfo;
+import lombok.Getter;
+
+@Getter
+public class BusinessException extends RuntimeException{
+
+    private ErrorInfo errorInfo;
+
+    public BusinessException(ErrorInfo errorInfo) {
+        this.errorInfo = errorInfo;
+    }
+}

--- a/src/main/java/com/backmin/domains/common/exception/BusinessException.java
+++ b/src/main/java/com/backmin/domains/common/exception/BusinessException.java
@@ -4,7 +4,7 @@ import com.backmin.domains.common.enums.ErrorInfo;
 import lombok.Getter;
 
 @Getter
-public class BusinessException extends RuntimeException{
+public class BusinessException extends RuntimeException {
 
     private ErrorInfo errorInfo;
 

--- a/src/main/java/com/backmin/domains/common/exception/StoreNotFoundException.java
+++ b/src/main/java/com/backmin/domains/common/exception/StoreNotFoundException.java
@@ -1,0 +1,10 @@
+package com.backmin.domains.common.exception;
+
+import com.backmin.domains.common.enums.ErrorInfo;
+
+public class StoreNotFoundException extends BusinessException {
+
+    public StoreNotFoundException() {
+        super(ErrorInfo.STORE_NOT_FOUND);
+    }
+}

--- a/src/main/java/com/backmin/domains/menu/converter/MenuConverter.java
+++ b/src/main/java/com/backmin/domains/menu/converter/MenuConverter.java
@@ -1,7 +1,9 @@
 package com.backmin.domains.menu.converter;
 
 import com.backmin.domains.menu.domain.Menu;
+import com.backmin.domains.menu.dto.MenuInfoAtStoreDetail;
 import com.backmin.domains.menu.dto.MenuInfoAtStoreList;
+import com.backmin.domains.menu.dto.MenuOptionInfoAtStoreDetail;
 import com.backmin.domains.menu.dto.MenuOptionInfoAtStoreList;
 import java.util.List;
 import org.springframework.stereotype.Component;
@@ -19,6 +21,19 @@ public class MenuConverter {
                 menu.isPopular(),
                 menu.getPrice(),
                 menuOptionInfoAtStoreLists
+        );
+    }
+
+    public MenuInfoAtStoreDetail convertMenuToMenuInfoAtStoreDetail(Menu menu, List<MenuOptionInfoAtStoreDetail> menuOptionInfoAtStoreDetails) {
+        return MenuInfoAtStoreDetail.of(
+                menu.getId(),
+                menu.getName(),
+                null,
+                menu.isBest(),
+                menu.isSoldOut(),
+                menu.isPopular(),
+                menu.getPrice(),
+                menuOptionInfoAtStoreDetails
         );
     }
 

--- a/src/main/java/com/backmin/domains/menu/converter/MenuOptionConverter.java
+++ b/src/main/java/com/backmin/domains/menu/converter/MenuOptionConverter.java
@@ -1,6 +1,7 @@
 package com.backmin.domains.menu.converter;
 
 import com.backmin.domains.menu.domain.MenuOption;
+import com.backmin.domains.menu.dto.MenuOptionInfoAtStoreDetail;
 import com.backmin.domains.menu.dto.MenuOptionInfoAtStoreList;
 import org.springframework.stereotype.Component;
 
@@ -9,6 +10,14 @@ public class MenuOptionConverter {
 
     public MenuOptionInfoAtStoreList convertMenuOptionToMenuOptionInfoAtStoreList(MenuOption menuOption) {
         return MenuOptionInfoAtStoreList.of(
+                menuOption.getId(),
+                menuOption.getName(),
+                menuOption.getPrice()
+        );
+    }
+
+    public MenuOptionInfoAtStoreDetail convertMenuOptionToMenuOptionInfoAtStoreDetail(MenuOption menuOption) {
+        return MenuOptionInfoAtStoreDetail.of(
                 menuOption.getId(),
                 menuOption.getName(),
                 menuOption.getPrice()

--- a/src/main/java/com/backmin/domains/menu/dto/MenuInfoAtStoreDetail.java
+++ b/src/main/java/com/backmin/domains/menu/dto/MenuInfoAtStoreDetail.java
@@ -1,0 +1,49 @@
+package com.backmin.domains.menu.dto;
+
+import java.util.List;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter @Setter
+public class MenuInfoAtStoreDetail {
+
+    private Long id;
+
+    private String name;
+
+    private String imageUrl;
+
+    private boolean isBest;
+
+    private boolean isSoldOut;
+
+    private boolean isPopular;
+
+    private int price;
+
+    private List<MenuOptionInfoAtStoreDetail> menuOptions;
+
+    public static MenuInfoAtStoreDetail of(
+            Long id,
+            String name,
+            String imageUrl,
+            boolean isBest,
+            boolean isSoldOut,
+            boolean isPopular,
+            int price,
+            List<MenuOptionInfoAtStoreDetail> menuOptions
+    ) {
+        MenuInfoAtStoreDetail menuInfoAtStoreDetail = new MenuInfoAtStoreDetail();
+        menuInfoAtStoreDetail.setId(id);
+        menuInfoAtStoreDetail.setName(name);
+        menuInfoAtStoreDetail.setImageUrl(imageUrl);
+        menuInfoAtStoreDetail.setBest(isBest);
+        menuInfoAtStoreDetail.setSoldOut(isSoldOut);
+        menuInfoAtStoreDetail.setPopular(isPopular);
+        menuInfoAtStoreDetail.setPrice(price);
+        menuInfoAtStoreDetail.setMenuOptions(menuOptions);
+
+        return menuInfoAtStoreDetail;
+    }
+
+}

--- a/src/main/java/com/backmin/domains/menu/dto/MenuOptionInfoAtStoreDetail.java
+++ b/src/main/java/com/backmin/domains/menu/dto/MenuOptionInfoAtStoreDetail.java
@@ -1,0 +1,25 @@
+package com.backmin.domains.menu.dto;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class MenuOptionInfoAtStoreDetail {
+
+    private Long optionId;
+
+    private String optionName;
+
+    private int optionPrice;
+
+    public static MenuOptionInfoAtStoreDetail of(Long optionId, String optionName, int optionPrice) {
+        MenuOptionInfoAtStoreDetail menuOptionInfoAtStoreDetail = new MenuOptionInfoAtStoreDetail();
+        menuOptionInfoAtStoreDetail.setOptionId(optionId);
+        menuOptionInfoAtStoreDetail.setOptionName(optionName);
+        menuOptionInfoAtStoreDetail.setOptionPrice(optionPrice);
+
+        return menuOptionInfoAtStoreDetail;
+    }
+
+}

--- a/src/main/java/com/backmin/domains/store/controller/StoreController.java
+++ b/src/main/java/com/backmin/domains/store/controller/StoreController.java
@@ -2,6 +2,7 @@ package com.backmin.domains.store.controller;
 
 import com.backmin.domains.common.dto.ApiResult;
 import com.backmin.domains.common.dto.PageDto;
+import com.backmin.domains.store.dto.DetailStoreInfoReadResponse;
 import com.backmin.domains.store.dto.StoreInfoAtList;
 import com.backmin.domains.store.service.StoreService;
 import lombok.RequiredArgsConstructor;
@@ -29,6 +30,15 @@ public class StoreController {
         PageDto<StoreInfoAtList> storeInfoAtListPageDto = storeService.readPagingStoresByCategoryId(categoryId, pageRequest);
 
         return ApiResult.ok(storeInfoAtListPageDto);
+    }
+
+    @GetMapping(value = "/stores/{storeId}",
+            consumes = MediaType.APPLICATION_JSON_VALUE,
+            produces = MediaType.APPLICATION_JSON_VALUE)
+    public ApiResult<DetailStoreInfoReadResponse> detail(@PathVariable("storeId") Long storeId) {
+        DetailStoreInfoReadResponse detailStoreInfoReadResponse = storeService.readDetailStore(storeId);
+
+        return ApiResult.ok(detailStoreInfoReadResponse);
     }
 
 }

--- a/src/main/java/com/backmin/domains/store/converter/StoreConverter.java
+++ b/src/main/java/com/backmin/domains/store/converter/StoreConverter.java
@@ -2,6 +2,7 @@ package com.backmin.domains.store.converter;
 
 import com.backmin.domains.menu.dto.MenuInfoAtStoreList;
 import com.backmin.domains.store.domain.Store;
+import com.backmin.domains.store.dto.StoreInfoAtDetail;
 import com.backmin.domains.store.dto.StoreInfoAtList;
 import java.util.List;
 import org.springframework.stereotype.Component;
@@ -22,6 +23,20 @@ public class StoreConverter {
                 0, // TODO : 평균 평점 넣기
                 0, // TODO : 총 리뷰 수 넣기
                 menuInfoAtStoreLists
+        );
+    }
+
+    public StoreInfoAtDetail convertToStoreInfoAtDetail(Store store) {
+        return StoreInfoAtDetail.of(
+                store.getId(),
+                store.getName(),
+                store.getPhoneNumber(),
+                store.getStoreIntro(),
+                store.getMinOrderPrice(),
+                store.getMinDeliveryTime(),
+                store.getMaxDeliveryTime(),
+                store.getDeliveryTip(),
+                store.isPackage()
         );
     }
 

--- a/src/main/java/com/backmin/domains/store/domain/StoreRepository.java
+++ b/src/main/java/com/backmin/domains/store/domain/StoreRepository.java
@@ -1,11 +1,17 @@
 package com.backmin.domains.store.domain;
 
+import java.util.Optional;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
 public interface StoreRepository extends JpaRepository<Store, Long> {
 
     Page<Store> findPagingStoresByCategoryId(Long categoryId, Pageable pageable);
+
+    @Query("select distinct s from Store s "
+           + "join fetch s.menus m ")
+    Optional<Store> findStoreById(Long storeId);
 
 }

--- a/src/main/java/com/backmin/domains/store/dto/DetailStoreInfoReadResponse.java
+++ b/src/main/java/com/backmin/domains/store/dto/DetailStoreInfoReadResponse.java
@@ -1,0 +1,31 @@
+package com.backmin.domains.store.dto;
+
+import com.backmin.domains.menu.dto.MenuInfoAtStoreDetail;
+import java.util.List;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class DetailStoreInfoReadResponse {
+
+    private StoreInfoAtDetail store;
+
+    private List<MenuInfoAtStoreDetail> bestMenus;
+
+    private List<MenuInfoAtStoreDetail> menus;
+
+    public static DetailStoreInfoReadResponse of(
+            StoreInfoAtDetail store,
+            List<MenuInfoAtStoreDetail> bestMenus,
+            List<MenuInfoAtStoreDetail> menus
+    ) {
+        DetailStoreInfoReadResponse detailStoreInfoReadResponse = new DetailStoreInfoReadResponse();
+        detailStoreInfoReadResponse.setStore(store);
+        detailStoreInfoReadResponse.setBestMenus(bestMenus);
+        detailStoreInfoReadResponse.setMenus(menus);
+
+        return detailStoreInfoReadResponse;
+    }
+
+}

--- a/src/main/java/com/backmin/domains/store/dto/StoreInfoAtDetail.java
+++ b/src/main/java/com/backmin/domains/store/dto/StoreInfoAtDetail.java
@@ -1,0 +1,53 @@
+package com.backmin.domains.store.dto;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class StoreInfoAtDetail {
+
+    private Long storeId;
+
+    private String storeName;
+
+    private String phoneNumber;
+
+    private String storeIntro;
+
+    private int minOrderPrice;
+
+    private int minDeliveryTime;
+
+    private int maxDeliveryTime;
+
+    private int deliveryTip;
+
+    private boolean isPackage;
+
+    public static StoreInfoAtDetail of(
+            Long storeId,
+            String storeName,
+            String phoneNumber,
+            String storeIntro,
+            int minOrderPrice,
+            int minDeliveryTime,
+            int maxDeliveryTime,
+            int deliveryTip,
+            boolean isPackage
+    ) {
+        StoreInfoAtDetail storeInfoAtDetail = new StoreInfoAtDetail();
+        storeInfoAtDetail.setStoreId(storeId);
+        storeInfoAtDetail.setStoreName(storeName);
+        storeInfoAtDetail.setPhoneNumber(phoneNumber);
+        storeInfoAtDetail.setStoreIntro(storeIntro);
+        storeInfoAtDetail.setMinOrderPrice(minOrderPrice);
+        storeInfoAtDetail.setMinDeliveryTime(minDeliveryTime);
+        storeInfoAtDetail.setMaxDeliveryTime(maxDeliveryTime);
+        storeInfoAtDetail.setDeliveryTip(deliveryTip);
+        storeInfoAtDetail.setPackage(isPackage);
+
+        return storeInfoAtDetail;
+    }
+
+}

--- a/src/main/java/com/backmin/domains/store/service/StoreService.java
+++ b/src/main/java/com/backmin/domains/store/service/StoreService.java
@@ -1,14 +1,18 @@
 package com.backmin.domains.store.service;
 
 import com.backmin.domains.common.dto.PageDto;
+import com.backmin.domains.common.exception.StoreNotFoundException;
 import com.backmin.domains.menu.converter.MenuConverter;
 import com.backmin.domains.menu.converter.MenuOptionConverter;
 import com.backmin.domains.menu.domain.Menu;
 import com.backmin.domains.menu.domain.MenuRepository;
+import com.backmin.domains.menu.dto.MenuInfoAtStoreDetail;
 import com.backmin.domains.menu.dto.MenuInfoAtStoreList;
 import com.backmin.domains.store.converter.StoreConverter;
 import com.backmin.domains.store.domain.Store;
 import com.backmin.domains.store.domain.StoreRepository;
+import com.backmin.domains.store.dto.DetailStoreInfoReadResponse;
+import com.backmin.domains.store.dto.StoreInfoAtDetail;
 import com.backmin.domains.store.dto.StoreInfoAtList;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -50,6 +54,34 @@ public class StoreService {
                 .pageNumber(storeSlice.getNumber())
                 .totalCount(storeSlice.getTotalElements())
                 .build();
+    }
+
+    public DetailStoreInfoReadResponse readDetailStore(Long storeId) {
+        Store foundStore = storeRepository.findStoreById(storeId)
+                .orElseThrow(() -> new StoreNotFoundException());
+
+        StoreInfoAtDetail storeInfo = storeConverter.convertToStoreInfoAtDetail(foundStore);
+
+        List<MenuInfoAtStoreDetail> bestMenuInfos = menuRepository.findBestMenusByStore(storeId).stream()
+                .map(this::getConvertedMenuInfoAtStoreDetail)
+                .collect(Collectors.toList());
+
+        List<MenuInfoAtStoreDetail> menuInfos = foundStore.getMenus().stream()
+                .map(this::getConvertedMenuInfoAtStoreDetail
+                ).collect(Collectors.toList());
+
+        return DetailStoreInfoReadResponse.of(
+                storeInfo,
+                bestMenuInfos,
+                menuInfos
+        );
+    }
+
+    private MenuInfoAtStoreDetail getConvertedMenuInfoAtStoreDetail(Menu menu) {
+        return menuConverter.convertMenuToMenuInfoAtStoreDetail(
+                menu,
+                menu.getMenuOptions().stream()
+                        .map(menuOptionConverter::convertMenuOptionToMenuOptionInfoAtStoreDetail).collect(Collectors.toList()));
     }
 
     private MenuInfoAtStoreList getConvertedMenuInfoAtStoreList(Menu menu) {

--- a/src/main/java/com/backmin/domains/store/service/StoreService.java
+++ b/src/main/java/com/backmin/domains/store/service/StoreService.java
@@ -81,7 +81,8 @@ public class StoreService {
         return menuConverter.convertMenuToMenuInfoAtStoreDetail(
                 menu,
                 menu.getMenuOptions().stream()
-                        .map(menuOptionConverter::convertMenuOptionToMenuOptionInfoAtStoreDetail).collect(Collectors.toList()));
+                        .map(menuOptionConverter::convertMenuOptionToMenuOptionInfoAtStoreDetail)
+                        .collect(Collectors.toList()));
     }
 
     private MenuInfoAtStoreList getConvertedMenuInfoAtStoreList(Menu menu) {

--- a/src/test/java/com/backmin/domains/store/controller/StoreControllerTest.java
+++ b/src/test/java/com/backmin/domains/store/controller/StoreControllerTest.java
@@ -5,7 +5,14 @@ import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
+import com.backmin.domains.menu.domain.Menu;
+import com.backmin.domains.menu.domain.MenuOption;
+import com.backmin.domains.store.domain.Category;
+import com.backmin.domains.store.domain.CategoryRepository;
+import com.backmin.domains.store.domain.Store;
+import com.backmin.domains.store.domain.StoreRepository;
 import com.backmin.domains.store.service.StoreService;
+import java.util.List;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -25,7 +32,10 @@ class StoreControllerTest {
     private MockMvc mockMvc;
 
     @Autowired
-    private StoreService storeService;
+    private CategoryRepository categoryRepository;
+
+    @Autowired
+    private StoreRepository storeRepository;
 
     @Test
     @DisplayName("카테고리 별 가게 목록 조회 테스트")
@@ -42,6 +52,54 @@ class StoreControllerTest {
                 .andExpect(jsonPath("data.pageSize").exists())
                 .andExpect(jsonPath("data.hasNext").exists())
                 .andExpect(jsonPath("data.list").exists())
+                .andExpect(jsonPath("serverDatetime").exists())
+                .andDo(print());
+    }
+
+    @Test
+    @DisplayName("가게 상세조회 테스트")
+    void test_detail() throws Exception {
+
+        // given
+        Category category1 = Category.builder()
+                .name("한식")
+                .build();
+        categoryRepository.save(category1);
+
+        MenuOption option1 = MenuOption.of("치즈추가", 500);
+        MenuOption option2 = MenuOption.of("사리추가", 600);
+        MenuOption option3 = MenuOption.of("감자추가", 700);
+        MenuOption option4 = MenuOption.of("고구마추가", 800);
+        List<MenuOption> menuOptions1 = List.of(option1, option2);
+        List<MenuOption> menuOptions2 = List.of(option3, option4);
+
+        Menu menu1 = Menu.of("엽기떡볶이", true, false, true, 17000, "겁나 맛있는 떡볶이입니다.", menuOptions1);
+        Menu menu2 = Menu.of("치즈떡볶이", true, false, true, 18000, "겁나 맛있는 치즈 떡볶이입니다.", menuOptions2);
+        List<Menu> menus = List.of(menu1, menu2);
+
+        Store store1 = Store.of(
+                "동대문 엽기 떡볶이",
+                "070364532746",
+                "엽떡집입니다.",
+                1000,
+                30,
+                60,
+                2000,
+                true,
+                true,
+                category1,
+                menus
+        );
+        Store savedStore = storeRepository.save(store1);
+
+        mockMvc.perform(get("/api/v1/bm/stores/{storeId}", savedStore.getId())
+                .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("success").value(true))
+                .andExpect(jsonPath("data").exists())
+                .andExpect(jsonPath("data.store").exists())
+                .andExpect(jsonPath("data.bestMenus").exists())
+                .andExpect(jsonPath("data.menus").exists())
                 .andExpect(jsonPath("serverDatetime").exists())
                 .andDo(print());
     }

--- a/src/test/java/com/backmin/domains/store/domain/StoreRepositoryTest.java
+++ b/src/test/java/com/backmin/domains/store/domain/StoreRepositoryTest.java
@@ -2,9 +2,14 @@ package com.backmin.domains.store.domain;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.hamcrest.Matchers.samePropertyValuesAs;
 
+import com.backmin.domains.menu.domain.Menu;
+import com.backmin.domains.menu.domain.MenuOption;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.stream.Collectors;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -90,6 +95,7 @@ class StoreRepositoryTest {
                 category1,
                 new ArrayList<>() // menus
         );
+
         List<Store> stores = List.of(store1, store2, store3, store4);
         storeRepository.saveAll(stores);
 
@@ -103,6 +109,56 @@ class StoreRepositoryTest {
         assertThat(storeByCategoryId.getTotalElements(), is(Long.valueOf(stores.size())));
         assertThat(storeByCategoryId.getContent().size(), is(PAGE_SIZE));
         assertThat(storeByCategoryId.hasNext(), is(true));
+    }
+
+    @Test
+    @DisplayName("가게 상세조회 테스트")
+    void test_findStoreById() {
+        // given
+        Category category1 = Category.builder()
+                .name("한식")
+                .build();
+        categoryRepository.save(category1);
+
+        MenuOption option1 = MenuOption.of("치즈추가", 500);
+        MenuOption option2 = MenuOption.of("사리추가", 600);
+        MenuOption option3 = MenuOption.of("감자추가", 700);
+        MenuOption option4 = MenuOption.of("고구마추가", 800);
+        List<MenuOption> menuOptions1 = List.of(option1, option2);
+        List<MenuOption> menuOptions2 = List.of(option3, option4);
+
+        Menu menu1 = Menu.of("엽기떡볶이", true, false, true, 17000, "겁나 맛있는 떡볶이입니다.", menuOptions1);
+        Menu menu2 = Menu.of("치즈떡볶이", true, false, true, 18000, "겁나 맛있는 치즈 떡볶이입니다.", menuOptions2);
+        List<Menu> menus = List.of(menu1, menu2);
+
+        Store store1 = Store.of(
+                "동대문 엽기 떡볶이",
+                "070364532746",
+                "엽떡집입니다.",
+                1000,
+                30,
+                60,
+                2000,
+                true,
+                true,
+                category1,
+                menus
+        );
+        storeRepository.save(store1);
+
+        Store foundStore = storeRepository.findStoreById(store1.getId()).get();
+
+        assertThat(foundStore, notNullValue());
+        assertThat(foundStore.getId(), is(store1.getId()));
+
+        List<Long> menuIdsBefore = menus.stream()
+                .map(menu -> menu.getId())
+                .collect(Collectors.toList());
+        List<Long> menuIdsAfter = foundStore.getMenus().stream()
+                .map(menu -> menu.getId())
+                .collect(Collectors.toList());
+        assertThat(menuIdsBefore, samePropertyValuesAs(menuIdsAfter));
+
     }
 
 }


### PR DESCRIPTION
- [x] 가게, 메뉴, 메뉴카테고리 , 옵션 카테고리, 옵션 데이터를 저장할 DTO를 생성한다.
- [x] 가게, 메뉴, 메뉴카테고리 , 옵션 카테고리, 옵션 데이터를 DTO로 변환할 Converter를 구현합니다.
- [x] 가게  상세정보 조회 기능을 구현합니다.
- [x] 메뉴 목록 조회 기능을 구현합니다.
- [x] 옵션 목록 조회 기능을 구현합니다.
- [x] 가게 상세정보, 메뉴 목록, 메뉴 별 옵션 목록, 대표메뉴 목록을 취합해서 "가게 상세정보 조회" 기능을 구현합니다.
- [x] 가게 상세정보 조회 기능에 대한 테스트 코드를 작성합니다.